### PR TITLE
Add language support to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ all: install
 
 tuxi:
 
-install:
+install: language
 	mkdir -p ${DESTDIR}${PREFIX}/bin
 	cp tuxi ${DESTDIR}${PREFIX}/bin/tuxi
+
+language:
+	sed -i 's/^LANGUAGE=""/LANGUAGE="${LANGUAGE}"/' tuxi
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/tuxi


### PR DESCRIPTION
Following up on #151, this PR enables users to set the language via `make` rather than manually editing the script, e.g.,

```bash
$ make LANGUAGE="en_US" install
```