### PR TITLE
small tweaks to main, updated test script

### DIFF
--- a/tests/testqueries.txt
+++ b/tests/testqueries.txt
@@ -21,14 +21,14 @@
 # rich
 # kno_right
 
-# did_you_mean Linux Tarvalds
-# did_you_mean waht is the office
-# did_you_mean hwo much is btc wroth
-# 
-# math log(30)
-# math 72^43/12(44+1)-3124
-# math (40/3)+4*6
-# math 45/sqrt(4)*3
+did_you_mean Linux Tarvalds
+did_you_mean waht is the office
+did_you_mean hwo much is btc wroth
+
+math log(30)
+math 72^43/12(44+1)-3124
+math (40/3)+4*6
+math 45/sqrt(4)*3
 
 basic/kno_val christmas day
 basic/kno_val summer solstice

--- a/tests/testqueries.txt
+++ b/tests/testqueries.txt
@@ -1,4 +1,4 @@
-## format: target query
+## format: target/target query
 # tests can be disabled by commenting out the lines
 
 ## target list:
@@ -21,28 +21,28 @@
 # rich
 # kno_right
 
-did_you_mean Linux Tarvalds
-did_you_mean waht is the office
-did_you_mean hwo much is btc wroth
+# did_you_mean Linux Tarvalds
+# did_you_mean waht is the office
+# did_you_mean hwo much is btc wroth
+# 
+# math log(30)
+# math 72^43/12(44+1)-3124
+# math (40/3)+4*6
+# math 45/sqrt(4)*3
 
-math log(30)
-math 72^43/12(44+1)-3124
-math (40/3)+4*6
-math 45/sqrt(4)*3
-
-basic christmas day
-basic summer solstice
-basic shortest day of the year
+basic/kno_val christmas day
+basic/kno_val summer solstice
+basic/kno_val shortest day of the year
 
 kno_top the office cast
 kno_top legends of runeterra
 kno_top reddit
 kno_top twitter
 
-rich elevation of mt everest
-rich what is elevation of mt rainier
-rich how big is the grand canyon
-rich how long is the yellow river?
+rich/kno_val elevation of mt everest
+rich/kno_val what is elevation of mt rainier
+rich/kno_val how big is the grand canyon
+rich/kno_val how long is the yellow river?
 
 feat the meaning of life the universe and everything else
 feat shotgun doom eternal
@@ -104,5 +104,3 @@ richcast cast of event horizon
 richcast cast of equalibrium
 richcast GoT stars
 richcast avengers actors
-
-lists Need for Speed Heat cars list

--- a/tuxi
+++ b/tuxi
@@ -12,7 +12,7 @@
 # if you find more than one answer is being printed (and you're not using -a)
 # increase this number by a little (you want it to be as low as possible)
 # this can also be set in your shell environment with TUXI_DELAY=
-[ -n "$TUXI_DELAY" ] && MICRO_DELAY="$TUXI_DELAY" || MICRO_DELAY=100
+[ -n "$TUXI_DELAY" ] && MICRO_DELAY="$TUXI_DELAY" || MICRO_DELAY=150
 
 VERSION="dev 2.0"
 MAIN_PID="$$"
@@ -44,25 +44,25 @@ fi
 # the first word should be the name of the a_function() followed by a space
 # you can disable tests by commenting out the line(s)
 priority="
+richcast        # Rich Rich Answers ( eg: social network cast )
+basic           # Basic Answers ( eg: christmas day )
 math            # Math ( eg: log_2(3) * pi^e )
+feat            # Featured Snippets ( eg: who is garfield )
 kno_val         # Chem facts ( eg: density of silver, density of hydrogen, what is the triple point of oxygen )
 kno_top         # Knowledge Graph - top ( list ) ( eg: the office cast )
-richcast        # Rich Rich Answers ( eg: social network cast )
+kno_right       # Knowledge Graph - right ( eg: the office )
 define          # Define ( eg: define Aggrandize )
+pronounce       # Learn to pronounce ( eg: pronounce linux )
 weather         # Weather ( eg: weather new york )
-lyrics_int      # Lyrics ( eg: gecgecgec lyrics )
-lyrics_us       # Lyrics for US users, above does not work for US
-quotes          # Quotes ( eg: mahatma gandhi quotes )
-basic           # Basic Answers ( eg: christmas day )
-rich            # Rich Answers ( eg: elevation of mount everest )
-feat            # Featured Snippets ( eg: who is garfield )
 lists           # Simple lists ( eg Need for Speed Heat cars list )
 unit            # Units Conversion ( eg: 1m into 1 cm )
 currency        # Currency Conversion ( eg: 1 USD in rupee )
 trans           # Translate ( eg: Vais para cascais? em ingles )
-pronounce       # Learn to pronounce ( eg: pronounce linux )
 sport_fixture   # Shows last or next fixture of a sports team ( eg. Chelsea next game )
-kno_right       # Knowledge Graph - right ( eg: the office )
+quotes          # Quotes ( eg: mahatma gandhi quotes )
+lyrics_int      # Lyrics ( eg: gecgecgec lyrics )
+lyrics_us       # Lyrics for US users, above does not work for US
+rich            # Rich Answers ( eg: elevation of mount everest )
 "
 
 ##############################
@@ -575,7 +575,6 @@ fi
 # loops to spin wheels until an answer has been found
 # if all the launched processes exit without an answer being found
 # script exits with a "No Result!" message
-laps=0
 while [ $answers_found -eq 0 ]; do
     for waiting1 in $(printf '%b\n' "$pids"); do
         kill -0 "$waiting1" 1>/dev/null 2>&1
@@ -584,8 +583,6 @@ while [ $answers_found -eq 0 ]; do
             kill -0 "$waiting2" 1>/dev/null 2>&1
             [ $? -eq 0 ] && break 2
         done
-        laps=$(($laps + 1))
-        [ $laps -lt 1 ] && break
         error_msg "No Result!"
         $debug && debug_info
         exit 1
@@ -612,11 +609,10 @@ if ! $all; then
 fi
 
 # once an answer has been printed and the -a flag isn't active
-# kills all remaining child processes in LIFO order
+# kills all remaining child processes
 # if -a flag is active then it waits until every answer has been printed first
 if ! $all; then
-    kill_pids="$(printf '%b\n' "$pids" | sort -r)"
-    for kids in $(printf '%b\n' "$kill_pids"); do
+    for kids in $(printf '%b\n' "$pids"); do
         kill -0 "$kids" 1>/dev/null 2>&1
         [ $? -eq 0 ] && kill "$kids" 1>/dev/null 2>&1
     done

--- a/tuxi
+++ b/tuxi
@@ -568,7 +568,7 @@ if ! $quiet; then
             replacement=$(printf '%s\n' "$replacement" | sed -e 's/[\/&]/\\&/g')
             did_you_mean=$(printf '%b\n' "$did_you_mean" | sed "s/${errors}/${replacement}/g")
         done
-        info_msg "$(printf 'did you mean %b"%b"%b ?\n' "$B" "$did_you_mean" "$N")"
+        info_msg "$(printf 'did you mean "%b%b%b" ?\n' "$B" "$did_you_mean" "$N")"
     fi
 fi
 

--- a/tuxi
+++ b/tuxi
@@ -618,5 +618,12 @@ if ! $all; then
     done
 fi
 $all && wait
+# another small delay as wait sometimes doesn't seem to wait quite long enough
+# for the last answer to be printed before exiting.
+l=0
+until [ $l -eq $(($MICRO_DELAY * 2)) ]; do
+    [ true ]
+    l=$(($l + 1))
+done
 $debug && debug_info
 exit 0


### PR DESCRIPTION
made minor tweaks to the delays and priority on the main script

updated the test script with a new fail state if more than one answer is printed and the ability to target more than one correct answer.

The latter because a few of the snippets display the same information so there can be multiple good answers to print.

![scrot_20210302-104221](https://user-images.githubusercontent.com/53883649/109637455-b9cacb80-7b44-11eb-8514-562e8dc37706.png)

in this case both kno_val and rich could be accepted as a correct answer.

really just need a few more people testing the script now and going through the test queries to properly highlight what are acceptable answers for each query and checking the results to see how best to tweak the priority