### PR TITLE
Use uname instead of OSTYPE to detect Darwin

### DIFF
--- a/tuxi
+++ b/tuxi
@@ -33,8 +33,8 @@ MAIN_PID=$$
 
 # credit to @Zhann in #149
 #   to use it, you will need to have GNU core utils installed
-case $OSTYPE in
-darwin*)
+case $(uname) in
+Darwin)
     sed() {
         gsed "$@"
     }


### PR DESCRIPTION
Since `$OSTYPE` is not POSIX-compatible, I replace it with `uname` to detect the platform instead.